### PR TITLE
vhost-user-vsock: enable savevm/loadvm for VM snapshots

### DIFF
--- a/hw/virtio/vhost-user-vsock.c
+++ b/hw/virtio/vhost-user-vsock.c
@@ -15,6 +15,7 @@
 #include "hw/core/qdev-properties.h"
 #include "hw/core/qdev-properties-system.h"
 #include "hw/virtio/vhost-user-vsock.h"
+#include "migration/blocker.h"
 
 static const int user_feature_bits[] = {
     VIRTIO_F_VERSION_1,
@@ -91,7 +92,14 @@ static uint64_t vuv_get_features(VirtIODevice *vdev,
 
 static const VMStateDescription vuv_vmstate = {
     .name = "vhost-user-vsock",
-    .unmigratable = 1,
+    .minimum_version_id = VHOST_VSOCK_SAVEVM_VERSION,
+    .version_id = VHOST_VSOCK_SAVEVM_VERSION,
+    .fields = (const VMStateField[]) {
+        VMSTATE_VIRTIO_DEVICE,
+        VMSTATE_END_OF_LIST()
+    },
+    .pre_save = vhost_vsock_common_pre_save,
+    .post_load = vhost_vsock_common_post_load,
 };
 
 static void vuv_device_realize(DeviceState *dev, Error **errp)
@@ -119,6 +127,16 @@ static void vuv_device_realize(DeviceState *dev, Error **errp)
     if (ret < 0) {
         goto err_virtio;
     }
+
+    /*
+     * Remove the vhost-level migration blocker. vhost_dev_init() blocks
+     * migration when the backend lacks VHOST_F_LOG_ALL (dirty-page tracking),
+     * which is a live-migration concern. For savevm/loadvm (in-process
+     * snapshots), dirty tracking is not needed — the VM is paused and all
+     * state is captured atomically. The vmstate hooks (pre_save/post_load)
+     * from vhost-vsock-common handle save/restore correctly.
+     */
+    migrate_del_blocker(&vvc->vhost_dev.migration_blocker);
 
     ret = vhost_dev_get_config(&vvc->vhost_dev, (uint8_t *)&vsock->vsockcfg,
                                sizeof(struct virtio_vsock_config), errp);


### PR DESCRIPTION
## Summary

This patch enables `savevm`/`loadvm` for the `vhost-user-vsock` device, allowing VM snapshots when vsock-based networking is in use (e.g., Penguin's VPN port forwarding).

Currently `vhost-user-vsock` is marked as non-migratable, blocking all snapshot operations even though the parent class (`vhost-vsock-common`) already provides correct save/restore hooks. The kernel-backed variant (`vhost-vsock`) uses these hooks and is fully migratable. This patch brings `vhost-user-vsock` to parity.

## Changes

Single file: `hw/virtio/vhost-user-vsock.c` (19 lines added, 1 removed)

**1. Replace unmigratable VMStateDescription with a proper one**

The empty `vuv_vmstate` with `.unmigratable = 1` is replaced with a vmstate that:
- Saves/restores `VMSTATE_VIRTIO_DEVICE` (virtio ring state, features, config)
- Uses `vhost_vsock_common_pre_save()` — asserts the vhost backend is stopped before save
- Uses `vhost_vsock_common_post_load()` — sends `VIRTIO_VSOCK_EVENT_TRANSPORT_RESET` after load so the guest kernel reconnects vsock sockets

This matches the kernel-backed `vhost-vsock` device exactly.

**2. Remove the vhost-level migration blocker after device init**

`vhost_dev_init()` registers a migration blocker when the backend lacks `VHOST_F_LOG_ALL` (dirty-page tracking for live migration). For `savevm`/`loadvm`, dirty tracking is unnecessary — the VM is paused and state is captured atomically. The blocker is removed after successful device initialization.

Note: `migrate_del_blocker()` removes the blocker for all migration modes. If live migration support is ever added for this device, the blocker handling should be revisited.

## Why this is safe

- `vm_stop()` is called before `savevm`, which triggers `virtio_vmstate_change()` -> `vuv_set_status(0)` -> `vhost_vsock_common_stop()`. The backend is guaranteed stopped when `pre_save` runs.
- The chardev/vhost-user connection survives same-process `savevm`/`loadvm` — nothing tears it down.
- On `loadvm`, `post_load` schedules a `VIRTIO_VSOCK_EVENT_TRANSPORT_RESET` via timer, telling the guest kernel to reconnect. `set_status` then restarts the backend.
- Changes are scoped entirely to `vhost-user-vsock` — no other devices are affected.

## Testing

- `make check` unit tests: 97 pass / 0 fail / 4 skip (unchanged from baseline)
- `qtest-x86_64/migration-test`: 40 subtests pass (unchanged from baseline)
- `savevm` with `vhost-user-vsock-pci` enabled: succeeds (previously blocked with "State blocked by non-migratable device")
- `loadvm` from snapshot: VM restores, guest receives transport reset
- End-to-end: validated with Penguin firmware emulations across multiple vendors (Netgear, D-Link, TP-Link) — services accessible after snapshot restore