### PR TITLE
feat(bql): Ensure BQL is held during after_machine_init

### DIFF
--- a/panda/src/panda_api.c
+++ b/panda/src/panda_api.c
@@ -18,11 +18,15 @@
 #include "panda/callbacks/cb-support.h"
 #include "panda/wrap_ops.h"
 
+#include "qemu/main-loop.h"
+
 // call main_aux and run everything up to and including panda_callbacks_after_machine_init
 int panda_init(int argc, char **argv, char **envp) {
     qemu_init(argc, argv);
     wrap_cpu_ops();
+    bql_lock();
     panda_callbacks_after_machine_init(first_cpu);
+    bql_unlock();
     return 0;
 }
 


### PR DESCRIPTION
This commit wraps the call to panda_callbacks_after_machine_init in panda_init with bql_lock() and bql_unlock().

This is critical to ensure that plugins (like the new native mmap manager) can safely perform Memory API operations during this callback without triggering bql_locked() assertion failures.